### PR TITLE
Big dictionary tests added. StructTuple wins

### DIFF
--- a/ConsoleApplication1/Program.cs
+++ b/ConsoleApplication1/Program.cs
@@ -38,6 +38,9 @@ namespace ConsoleApplication1
         private Dictionary<ImprovedTuple<string, int>, ImprovedTuple<string, int>> idict = new Dictionary<ImprovedTuple<string, int>, ImprovedTuple<string, int>>();
         private Dictionary<StructTuple<string, int>, StructTuple<string, int>> sdict = new Dictionary<StructTuple<string, int>, StructTuple<string, int>>();
         private Dictionary<string, string> strdict = new Dictionary<string, string>();
+        private Dictionary<ImprovedTuple<string, int>, ImprovedTuple<string, int>> idictBig;
+        private Dictionary<StructTuple<string, int>, StructTuple<string, int>> sdictBig;
+        private Dictionary<Tuple<string, int>, Tuple<string, int>> dictBig;
 
         public Program()
         {
@@ -54,6 +57,19 @@ namespace ConsoleApplication1
             this.idict[ituple1] = ituple2;
             this.sdict[stuple1] = stuple2;
             this.strdict[str1] = str2;
+            this.idictBig = new Dictionary<ImprovedTuple<string, int>, ImprovedTuple<string, int>>(4096, iComparer);
+            this.sdictBig = new Dictionary<StructTuple<string, int>, StructTuple<string, int>>(4096, sComparer2);
+            this.dictBig = new Dictionary<Tuple<string, int>, Tuple<string, int>>(4096, EqualityComparer<Tuple<string, int>>.Default);
+            var rand = new Random(1234);
+            for (int i = 0; i < 2048; i++)
+            {
+                idictBig.Add(new ImprovedTuple<string, int>(rand.Next().ToString(), i), new ImprovedTuple<string, int>(i.ToString(), i));
+                sdictBig.Add(new StructTuple<string, int>(rand.Next().ToString(), i), new StructTuple<string, int>(i.ToString(), i));
+                dictBig.Add(new Tuple<string, int>(rand.Next().ToString(), i), new Tuple<string, int>(i.ToString(), i));
+            }
+            idictBig.Add(ituple1, ituple2);
+            sdictBig.Add(stuple1, stuple2);
+            dictBig.Add(tuple1, tuple2);
         }
 
         static void Main(string[] args)
@@ -175,6 +191,24 @@ namespace ConsoleApplication1
         public void StringDictionaryContainsKey()
         {
             this.strdict.ContainsKey(str1);
+        }
+
+        [Benchmark]
+        public void BigDictionaryContainsKey()
+        {
+            this.dictBig.ContainsKey(Tuple.Create(str1, i1));
+        }
+
+        [Benchmark]
+        public void BigImprovedDictionaryContainsKey()
+        {
+            this.idictBig.ContainsKey(new ImprovedTuple<string, int>(str1, i1));
+        }
+
+        [Benchmark]
+        public void BigStructDictionaryContainsKey()
+        {
+            this.sdictBig.ContainsKey(new StructTuple<string, int>(str1, i1));
         }
     }
 


### PR DESCRIPTION
// Benchmark: Program_BigDictionaryContainsKey (Throughput_CurrentPlatform_CurrentJit_NET-Current) [-w=0 -t=1]
// Generated project: C:\Projects\TupleBenchmark\ConsoleApplication1\bin\Release\Program_BigDictionaryContainsKey_Throughput_CurrentPlatform_CurrentJit_NET-Current

AverageTime (ns/op): Median = 182.69264; StdDev = 0; Min = 182.69264; Max = 182.69264;
OperationsPerSecond: Median = 5473674.12337; StdDev = 0; Min = 5473674.12337; Max = 5473674.12337;

// **************************
// Benchmark: Program_BigImprovedDictionaryContainsKey (Throughput_CurrentPlatform_CurrentJit_NET-Current) [-w=0 -t=1]
// Generated project: C:\Projects\TupleBenchmark\ConsoleApplication1\bin\Release\Program_BigImprovedDictionaryContainsKey_Throughput_CurrentPlatform_CurrentJit_NET-Current

AverageTime (ns/op): Median = 60.51462; StdDev = 0; Min = 60.51462; Max = 60.51462;
OperationsPerSecond: Median = 16524931.18803; StdDev = 0; Min = 16524931.18803; Max = 16524931.18803;

// **************************
// Benchmark: Program_BigStructDictionaryContainsKey (Throughput_CurrentPlatform_CurrentJit_NET-Current) [-w=0 -t=1]
// Generated project: C:\Projects\TupleBenchmark\ConsoleApplication1\bin\Release\Program_BigStructDictionaryContainsKey_Throughput_CurrentPlatform_CurrentJit_NET-Current

AverageTime (ns/op): Median = 57.02796; StdDev = 0; Min = 57.02796; Max = 57.02796;
OperationsPerSecond: Median = 17535259.01817; StdDev = 0; Min = 17535259.01817; Max = 17535259.01817;
